### PR TITLE
Add filename placeholders %width and %height to the`Prompt Saver` node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -456,6 +456,8 @@ class SDPromptSaver:
                 "%seed": seed,
                 "%steps": steps,
                 "%cfg": cfg,
+                "%width": width,
+                "%height": height,
                 "%extension": extension,
                 "%model": Path(model_name_real).stem,
                 "%sampler": sampler_name_real,


### PR DESCRIPTION
There's probably a reason this is not in the main branch, I assume because of certain node conflicts but it works for me!