### PR TITLE
Parameter Extractor: parse quoted parameters

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1218,17 +1218,20 @@ class SDParameterExtractor:
 
     @staticmethod
     def parse_setting(settings):
-        pattern = re.compile(r"([^:,]+):\s*\(([^)]+)\)|([^:,]+):\s*([^,]+)")
+        pattern = re.compile(r"([^:,]+):\s*\(([^)]+)\)|([^:,]+):\s*\"([^\"]+)\"|([^:,]+):\s*([^,]+)")
 
         matches = pattern.findall(settings)
 
         result = {}
         for match in matches:
-            key, value_paren, key_nonparen, value_nonparen = match
-            if key:
-                key = key.strip()
+            key_paren, value_paren, key_quotes, value_quotes, key_nonparen, value_nonparen = match
+            if key_paren:
+                key = key_paren.strip()
                 value = value_paren.strip()
                 value = tuple(v.strip() for v in value.split(","))
+            elif key_quotes:
+                key = key_quotes.strip()
+                value = value_quotes.strip()
             else:
                 key = key_nonparen.strip()
                 value = value_nonparen.strip()


### PR DESCRIPTION
ParameterExtractor: Parse qutoted Parameters including ',' 
I.e.
`ADetailer prompt: "score_9, score_8_up, score_7_up, beautiful eyes, blue eyes, detailed face, ", `
Which stopped parsing after first comma: 
![ADatailer_Extract_Failed](https://github.com/user-attachments/assets/e6305e24-acf2-48ae-bb20-d55cb6cfacf1)

Now parses whole string until closing quote
![ADatailer_Extract_Fixed](https://github.com/user-attachments/assets/dcb5336b-1529-45ec-a0f0-2c708698da89)
