### PR TITLE
Checkout submodules before publishing

### DIFF
--- a/.github/workflows/publish_registry.yml
+++ b/.github/workflows/publish_registry.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Publish Custom Node
         uses: Comfy-Org/publish-node-action@main
         with:


### PR DESCRIPTION
As I was testing your node on registry I realized that we never bundle the extern folder. After some digging, I realized it's because git clone will automatically check out the extern sub repositories. However, the checkout action does not.

Can we merge this and then publish a new version? The previous versions don't work so we can delete those as well if you prefer.